### PR TITLE
Call existing function to prevent repeating code

### DIFF
--- a/src/HL-phpclient/HLMembers.php
+++ b/src/HL-phpclient/HLMembers.php
@@ -45,8 +45,7 @@ class HLMembers extends HLBase
                 ]
             ]
         );
-        $this->endpoint = 'lists/'.$listId.'/members';
-        return $this->call('GET',$this->endpoint,$filter);
+        return $this->getMembersByFilter($listId,$filter);
     }
     
     /**


### PR DESCRIPTION
getMemberByEmail might as well just call getMembersByFilter after the filter array is built, as both list ID, method, and endpoint are still the same.