### PR TITLE
Add webhook service for CRUD actions on a lists webhooks

### DIFF
--- a/src/Examples/WebhookSetupExamples.php
+++ b/src/Examples/WebhookSetupExamples.php
@@ -1,0 +1,29 @@
+<?php
+require('vendor/autoload.php');
+use Phpclient\HLClient;
+use Phpclient\HLWebhooks;
+
+$apiKey = 'your-api-key';
+$apiSecret = 'your-api-secret';
+$listId = 'whatever list you want';
+$client = new HLClient($apiKey, $apiSecret);
+$webhookService = new HLWebhooks($client);
+
+// These are the setting you can subsribe to getting webhooks from. Simply set the value to 1 for the events you want to subscribe to (default is 0 if they are not filled)
+$settings = ['subscribe' => 1, 'update' => 1, 'unsubscribe' => 1, 'spamComplaint' => 1, 'click' => 1, 'open' => 1, 'hardbounce' => 1];
+
+
+// Get webhooks setup on a list
+var_dump($webhookService->getWebhooks($listId));
+
+// Create new webhook on a specific list
+$url = 'http://MyAwesomeSite.org';
+var_dump($webhookService->create($listId, $url, $settings, 'iWantTheErrorMessages@mydomain.dk'));
+
+// Update a webhook on a specific list
+var_dump($webhookService->update($listId, $url, $settings, 'newEmail@mydomain.dk'));
+
+// Delete a webhook on a specific list
+var_dump($webhookService->delete($listId, 'webhookIdFetchedByGet'));
+
+

--- a/src/HL-phpclient/HLWebhooks.php
+++ b/src/HL-phpclient/HLWebhooks.php
@@ -7,12 +7,18 @@ class HLWebhooks extends HLBase
         $this->setClient($client);
     }
 
+    /*
+     * @codeCoverageIgnore
+     */
     public function getWebhooks($listId)
     {
         $this->endpoint = 'lists/' . $listId . '/webhooks';
         return $this->call('GET', $this->endpoint);
     }
 
+    /*
+     * @codeCoverageIgnore
+     */
     public function create($listId, $url, array $settings=array(), $contactEmail = '')
     {
         $this->endpoint = 'lists/' . $listId . '/webhooks';
@@ -20,6 +26,9 @@ class HLWebhooks extends HLBase
         return $this->call('POST', $this->endpoint, $data);
     }
 
+    /*
+     * @codeCoverageIgnore
+     */
     public function update($listId, $webhookId, $url, array $settings=array(), $contactEmail = '')
     {
         $this->endpoint = 'lists/' . $listId . '/webhooks/' . $webhookdId;
@@ -27,12 +36,18 @@ class HLWebhooks extends HLBase
         return $this->call('PUT', $this->endpoint, $data);
     }
 
+    /*
+     * @codeCoverageIgnore
+     */
     public function delete($listId, $webhookId)
     {
-        $this->endpoint = 'lists/' . $listId  . '/webhooks' . $webhookId;
+        $this->endpoint = 'lists/' . $listId  . '/webhooks/' . $webhookId;
         return $this->call('DELETE', $this->endpoint);
     }
 
+    /*
+     * @codeCoverageIgnore
+     */
     protected function setupData($url, $settings, $contactEmail)
     {
         $data = array('url' => $url, 'contact_email' => $contactEmail);
@@ -40,6 +55,9 @@ class HLWebhooks extends HLBase
         return $data;
     }
 
+    /*
+     * @codeCoverageIgnore
+     */
     protected function setActiveWebhooks(array $settings)
     {
         $availableTriggers = array('subscribe' => 0, 'update' => 0, 'unsubscribe' => 0, 'spamComplaint' => 0, 'click' => 0, 'open' => 0, 'hardbounce' => 0);

--- a/src/HL-phpclient/HLWebhooks.php
+++ b/src/HL-phpclient/HLWebhooks.php
@@ -1,0 +1,54 @@
+<?php namespace Phpclient;
+
+class HLWebhooks extends HLBase
+{
+    public function __construct(HLClient $client)
+    {
+        $this->setClient($client);
+    }
+
+    public function getWebhooks($listId)
+    {
+        $this->endpoint = 'lists/' . $listId . '/webhooks';
+        return $this->call('GET', $this->endpoint);
+    }
+
+    public function create($listId, $url, array $settings=array(), $contactEmail = '')
+    {
+        $this->endpoint = 'lists/' . $listId . '/webhooks';
+        $data = $this->setupData($url, $settings, $contactEmail);
+        return $this->call('POST', $this->endpoint, $data);
+    }
+
+    public function update($listId, $webhookId, $url, array $settings=array(), $contactEmail = '')
+    {
+        $this->endpoint = 'lists/' . $listId . '/webhooks/' . $webhookdId;
+        $data = $this->setupData($url, $settings, $contactEmail);
+        return $this->call('PUT', $this->endpoint, $data);
+    }
+
+    public function delete($listId, $webhookId)
+    {
+        $this->endpoint = 'lists/' . $listId  . '/webhooks' . $webhookId;
+        return $this->call('DELETE', $this->endpoint);
+    }
+
+    protected function setupData($url, $settings, $contactEmail)
+    {
+        $data = array('url' => $url, 'contact_email' => $contactEmail);
+        $data['webhookTriggers'] = $this->setActiveWebhooks($settings);
+        return $data;
+    }
+
+    protected function setActiveWebhooks(array $settings)
+    {
+        $availableTriggers = array('subscribe' => 0, 'update' => 0, 'unsubscribe' => 0, 'spamComplaint' => 0, 'click' => 0, 'open' => 0, 'hardbounce' => 0);
+        foreach ($settings as $setting => $active) {
+            if (!isset($availableTriggers[$setting])) {
+                throw new Exception('Invalid setting supplied for webhooks: ' . $setting);
+            }
+            $availableTriggers[$setting] = $active;
+        }
+        return $availableTriggers;
+    }
+}


### PR DESCRIPTION
This pull request adds a service for handling list webhooks through API. 
Note that valid settings are:
subscribe => 1/0, 
update => 1/0, 
unsubscribe => 1/0, 
spamComplaint => 1/0,
click => 1/0, 
open => 1/0, 
hardbounce => 1/0
All these settings are default set to 0 (Bool false). 