### PR TITLE
Enable safe upload

### DIFF
--- a/src/HL-phpclient/HLCurlHandler.php
+++ b/src/HL-phpclient/HLCurlHandler.php
@@ -60,7 +60,6 @@ class HLCurlHandler
             case 'POST':
                 curl_setopt($curl, CURLOPT_URL, $url);
                 curl_setopt($curl, CURLOPT_POST, true);
-                curl_setopt($curl,CURLOPT_SAFE_UPLOAD,false);
                 curl_setopt($curl, CURLOPT_POSTFIELDS, $postFields);
                 break;
         }


### PR DESCRIPTION
Disabling safe upload isn't supported in PHP 7+.

```
ErrorException: curl_setopt(): Disabling safe uploads is no longer supported
```