### PR TITLE
Add service for link tracking

### DIFF
--- a/src/HL-phpclient/HLLinkTracking.php
+++ b/src/HL-phpclient/HLLinkTracking.php
@@ -1,0 +1,29 @@
+<?php namespace Phpclient;
+    /*
+         * This file is part of the hl-phpclient package.
+         *
+         * (c) René Skou <skou.rene@gmail.com>
+         *
+         * For the full copyright and license information, please view the LICENSE
+         * file that was distributed with this source code.
+         */
+
+class HLLinkTracking extends HLBase
+{
+    public function __construct(HLClient $client)
+    {
+        $this->setClient($client);
+    }
+
+    public function getSettings($id)
+    {
+        $this->endpoint = 'lists/' . $id . '/options/link_tracking';
+        return $this->call('GET',$this->endpoint);
+    }
+
+    public function update($listId,$params)
+    {
+        $this->endpoint = 'lists/' . $listId . '/options/link_tracking';
+        return $this->call('PUT',$this->endpoint,$params);
+    }
+}


### PR DESCRIPTION
This commit will add service for fetching and setting link tracking in heyloyalty. 
Making examples seems quite beyond the point since the format is "strange" at best. We should revisit this code at some point and rewrite it to have a more "expected" format.