### PR TITLE
Add routes for upsert and patch

### DIFF
--- a/src/Examples/MemberUpdateExamples.php
+++ b/src/Examples/MemberUpdateExamples.php
@@ -7,7 +7,7 @@ use Phpclient\HLMembers;
  */
 $apiKey = 'api-key';
 $apiSecret = 'api-secret';
-$listId = 123;
+$listId = 1234;
 $memberId = 'member-id';
 $client = new HLClient($apiKey,$apiSecret);
 $memberService = new HLMembers($client);
@@ -43,4 +43,37 @@ $fields = array(
 
 $result = $memberService->update($listId,$memberId,$fields);
 var_dump('update member with multi choice');
+var_dump($result);
+
+
+/**
+ * Patch a member.
+ *
+ * Requirements are just like put but instead of removing fields not parsed we just update the fields specified.
+ * This also ensures that we do not need to parse email or mobile field.
+ *
+ */
+$fields = [
+    'firstname' => 'test'
+];
+
+$result = $memberService->patch($listId, $memberId, $fields);
+var_dump('Patch member with firstname');
+var_dump($result);
+
+
+/**
+ * Upsert member. 
+ *
+ * Upsert member takes fields as update as well as a unique field. This unique field must be part of the fields sent.
+ * Note that we get an error if there's more than 1 member on the specific list with the specific field value so firstname is normally not a good idea for unique field.
+ *
+ */
+$uniqueField = 'firstname';
+$fields = [
+    'firstname' => 'test',
+    'mobile' => 12345678
+];
+$result = $memberService->upsert($listId, $uniqueField, $fields);
+var_dump('Upsert member with unique firstname');
 var_dump($result);

--- a/src/HL-phpclient/HLCurlHandler.php
+++ b/src/HL-phpclient/HLCurlHandler.php
@@ -56,6 +56,11 @@ class HLCurlHandler
                 curl_setopt($curl, CURLOPT_CUSTOMREQUEST,'PUT');
                 curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($postFields));
                 break;
+            case 'PATCH':
+                curl_setopt($curl, CURLOPT_URL, $url);
+                curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PATCH');
+                curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($postFields));
+                break;
             case 'POST':
                 curl_setopt($curl, CURLOPT_URL, $url);
                 curl_setopt($curl, CURLOPT_POST, true);

--- a/src/HL-phpclient/HLMembers.php
+++ b/src/HL-phpclient/HLMembers.php
@@ -102,8 +102,8 @@ class HLMembers extends HLBase
      */
     public function update($listId,$memberId,array $fields)
     {
-        $this->endpoint = 'lists/'.$listId.'/members/'.$memberId;
-        return $this->call('PUT',$this->endpoint,$fields);
+        $this->endpoint = 'lists/' . $listId . '/members/' . $memberId;
+        return $this->call('PUT', $this->endpoint, $fields);
     }
     
     /**
@@ -141,5 +141,19 @@ class HLMembers extends HLBase
         return $this->call('DELETE', "lists/{$listId}/members/{$memberId}", [
             'obscureMemberData' => true
         ]);
+    }
+
+    public function patch($listId, $memberId, array $fields)
+    {
+        return $this->call('PATCH', 'lists/' . $listId . '/members/' . $memberId, $fields);
+    }
+
+    public function upsert($listId, $uniqueField, array $fields)
+    {
+        $request = [
+            'unique_field' => $uniqueField,
+            'member' => $fields
+        ];
+        return $this->call('POST', 'lists/' . $listId . '/members/upsert', $request);
     }
 }


### PR DESCRIPTION
This PR adds handling for Upsert and Patch member endpoints 
Upsert handling is specified here https://github.com/Heyloyalty/api/wiki/Upsert-%E2%80%93-Create-or-update 
Patch is identical to update with the current "smartupdate" enabled 