### PR TITLE
Add the `ExternalFields` in the root of the data

### DIFF
--- a/src/HL-phpclient/HLWebhookCategory.php
+++ b/src/HL-phpclient/HLWebhookCategory.php
@@ -103,7 +103,7 @@ class HLWebhookCategory extends HLBase
      */
     public function addExternalField($key, $value)
     {
-        $this->messageBuilder['Context']['ExternalFields'][$key] = $value;
+        $this->messageBuilder['ExternalFields'][$key] = $value;
     }
 
     /*


### PR DESCRIPTION
As [the documentation](https://github.com/Heyloyalty/api/wiki/Webhook-category-autoresponder#sending-emails-through-hl-webhook-category) says the `ExternalFields` should be in the root of the JSON data and not in the `Context` key