### PR TITLE
Remove context where it should not have been

### DIFF
--- a/src/HL-phpclient/HLWebhookCategory.php
+++ b/src/HL-phpclient/HLWebhookCategory.php
@@ -103,7 +103,7 @@ class HLWebhookCategory extends HLBase
      */
     public function addExternalField($key, $value)
     {
-        $this->messageBuilder['Context']['ExternalFields'][$key] = $value;
+        $this->messageBuilder['ExternalFields'][$key] = $value;
     }
 
     /*


### PR DESCRIPTION
We by mistake set ExternalFields as part of the Context instead of in the root element as expected.